### PR TITLE
Remove JCenter from the Java starter

### DIFF
--- a/starter/java/.idea/jarRepositories.xml
+++ b/starter/java/.idea/jarRepositories.xml
@@ -11,10 +11,5 @@
       <option name="name" value="JBoss Community repository" />
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
-    <remote-repository>
-      <option name="id" value="BintrayJCenter" />
-      <option name="name" value="BintrayJCenter" />
-      <option name="url" value="https://jcenter.bintray.com/" />
-    </remote-repository>
   </component>
 </project>

--- a/starter/java/build.gradle
+++ b/starter/java/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
JCenter was discontinued about a year ago and it's no longer available:
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

I swapped it for Maven Central in the build script, which is fine since the JUnit dependencies are in Maven Central as well :)